### PR TITLE
Enabled copilot for markdown and yaml

### DIFF
--- a/autoload/copilot.vim
+++ b/autoload/copilot.vim
@@ -125,8 +125,6 @@ function! copilot#Dismiss() abort
 endfunction
 
 let s:filetype_defaults = {
-      \ 'yaml': 0,
-      \ 'markdown': 0,
       \ 'help': 0,
       \ 'gitcommit': 0,
       \ 'gitrebase': 0,


### PR DESCRIPTION
Udpated `autoload/copilot.vim` to enable suggestions for YAML and Markdown

At the moment we are not accepting contributions to the repository.
